### PR TITLE
ENH: [Breaking] Equilibrium solidification does a binary search for the solidus 

### DIFF
--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -5,7 +5,7 @@ from pycalphad.codegen.callables import build_callables
 from pycalphad.core.utils import instantiate_models, generate_dof, \
     unpack_components
 from .solidification_result import SolidifcationResult
-from .utils import order_disorder_dict, local_sample, order_disorder_eq_phases
+from .utils import order_disorder_dict, local_sample, order_disorder_eq_phases, get_phase_amounts
 
 NAN_DICT = defaultdict(lambda: np.nan)
 
@@ -169,6 +169,7 @@ def simulate_scheil_solidification(dbf, comps, phases, composition,
 def simulate_equilibrium_solidification(dbf, comps, phases, composition,
                                         start_temperature, step_temperature=1.0,
                                         liquid_phase_name='LIQUID', adaptive=True, eq_kwargs=None,
+                                        binary_search_tol=0.1,
                                         verbose=False):
     """
     Compute the equilibrium solidification path.
@@ -191,6 +192,8 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
         Name of the phase treated as liquid. Defaults to 'LIQUID'.
     eq_kwargs: Optional[Dict[str, Any]]
         Keyword arguments for equilibrium
+    binary_search_tol : float
+        Stop the binary search when the difference between temperatures is less than this amount.
     adaptive: Optional[bool]
         Whether to add additional points near the equilibrium points at each
         step. Only takes effect if ``points`` is in the eq_kwargs dict.
@@ -199,7 +202,7 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
     eq_kwargs = eq_kwargs or dict()
 
     solid_phases = sorted(set(phases) - {'GAS', liquid_phase_name})
-    independent_comps = sorted(composition.keys(), key=str)
+    independent_comps = sorted([str(comp)[2:] for comp in composition.keys()])
     models = instantiate_models(dbf, comps, phases)
     if verbose:
         print('building callables... ', end='')
@@ -215,36 +218,53 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
     phase_amounts = {ph: [] for ph in solid_phases}  # instantaneous phase amounts
     cum_phase_amounts = {ph: [] for ph in solid_phases}
     converged = False
-    curr_T = start_temperature
+    current_T = start_temperature
+    final_iteration = False  # "Final" iteration is after the binary search where we know the phases will be solid only
     while fraction_solid[-1] < 1 if len(fraction_solid) > 0 else True:
-        conds[v.T] = curr_T
-        eq = equilibrium(dbf, comps, phases, conds, callables=cbs)
-        curr_eq = eq.isel(N=0, T=0, P=0)
-        curr_fraction_solid = 0.0
-        # calculate the phase amounts
-        for solid_phase in solid_phases:
-            amount = float(np.nansum(curr_eq.NP.where(curr_eq.Phase == solid_phase).values))
-            # Since the equilibrium calculations always give the "cumulative" phase amount,
-            # we need to take the difference to get the instantaneous.
-            cum_phase_amounts[solid_phase].append(amount)
-            if len(phase_amounts[solid_phase]) == 0:
-                phase_amounts[solid_phase].append(amount)
-            else:
-                phase_amounts[solid_phase].append(amount - cum_phase_amounts[solid_phase][-2])
-            curr_fraction_solid += amount
-        fraction_solid.append(curr_fraction_solid)
+        conds[v.T] = current_T
+        eq = equilibrium(dbf, comps, phases, conds, callables=cbs, to_xarray=False)
+        current_eq = eq
+        if liquid_phase_name in current_eq.Phase or final_iteration:
+            # Calculate fraciton of solid and phase amounts, get liquid composition.
+            temperatures.append(current_T)
+            current_fraction_solid = 0.0
+            current_cum_phase_amnts = get_phase_amounts(current_eq, solid_phases)
+            for solid_phase, amount in current_cum_phase_amnts.items():
+                # Since the equilibrium calculations always give the "cumulative" phase amount,
+                # we need to take the difference to get the instantaneous.
+                cum_phase_amounts[solid_phase].append(amount)
+                if len(phase_amounts[solid_phase]) == 0:
+                    phase_amounts[solid_phase].append(amount)
+                else:
+                    phase_amounts[solid_phase].append(amount - cum_phase_amounts[solid_phase][-2])
+                current_fraction_solid += amount
+            fraction_solid.append(current_fraction_solid)
 
-        # liquid phase constitution
-        if 'LIQUID' in curr_eq.Phase.values:
-            # TODO: will break for liquid miscibility gap
-            liquid_vertex = sorted(np.nonzero(curr_eq.Phase.values.flat == 'LIQUID'))[0]
-            liquid_comp = {comp: float(curr_eq.X.isel(vertex=liquid_vertex).sel(component=str(comp)[2:]).values) for comp in independent_comps}
-            x_liquid.append(liquid_comp)
-            temperatures.append(curr_T)
-            curr_T -= step_temperature
+            if not final_iteration:
+                # Add the liquid phase composition
+                # TODO: will break in a liquid miscibility gap
+                liquid_vertex = np.nonzero(current_eq.Phase == liquid_phase_name)[-1][0]
+                liquid_comp = {comp: float(current_eq.X[..., liquid_vertex, current_eq.component.index(comp)]) for comp in independent_comps}
+                x_liquid.append(liquid_comp)
+                current_T -= step_temperature
+            else:
+                # Set the liquid phase composition to NaN
+                liquid_comp = {comp: float(np.nan) for comp in independent_comps}
+                x_liquid.append(liquid_comp)
         else:
-            x_liquid.append(np.nan)
-            temperatures.append(curr_T)
+            # binary search to find the solidus
+            T_high = current_T + step_temperature  # High temperature, liquid
+            T_low = current_T  # Low temperature, solids only
+            while (T_high - T_low) > binary_search_tol:
+                bin_search_T = (T_high - T_low)*0.5 + T_low
+                conds[v.T] = bin_search_T
+                eq = equilibrium(dbf, comps, phases, conds, callables=cbs, to_xarray=False)
+                if liquid_phase_name in eq.Phase:
+                    T_high = bin_search_T
+                else:
+                    T_low = bin_search_T
+            current_T = T_low
+            final_iteration = True  # perform one last iteration with the new temperature
 
     converged = np.isclose(fraction_solid[-1], 1.0)
     return SolidifcationResult(x_liquid, fraction_solid, temperatures, phase_amounts, converged)

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -24,20 +24,21 @@ def simulate_scheil_solidification(dbf, comps, phases, composition,
         List of components in the system.
     phases : list
         List of phases in the system.
-    composition : dict
+    composition : Dict[v.X, float]
         Dictionary of independent `v.X` composition variables.
     start_temperature : float
         Starting temperature for simulation. Must be single phase liquid.
     step_temperature : Optional[float]
         Temperature step size. Defaults to 1.0.
     liquid_phase_name : Optional[str]
-        Name of the phase treated as liquid.
+        Name of the phase treated as liquid. Defaults to 'LIQUID'.
     eq_kwargs: Optional[Dict[str, Any]]
         Keyword arguments for equilibrium
     stop: Optional[float]
         Stop when the phase fraction of liquid is below this amount.
     adaptive: Optional[bool]
-        Whether
+        Whether to add additional points near the equilibrium points at each
+        step. Only takes effect if ``points`` is in the eq_kwargs dict.
 
     Returns
     -------

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -219,7 +219,6 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
     cum_phase_amounts = {ph: [] for ph in solid_phases}
     converged = False
     current_T = start_temperature
-    final_iteration = False  # "Final" iteration is after the binary search where we know the phases will be solid only
     while fraction_solid[-1] < 1 if len(fraction_solid) > 0 else True:
         conds[v.T] = current_T
         eq = equilibrium(dbf, comps, phases, conds, callables=cbs, to_xarray=False)

--- a/scheil/solidification_result.py
+++ b/scheil/solidification_result.py
@@ -2,35 +2,36 @@ import numpy as np
 
 
 class SolidifcationResult():
-    """Short summary.
+    """Data from an equilibrium or Scheil-Gulliver solidification simulation.
 
     Parameters
     ----------
-    temperatures : list
+    x_liquid : Dict[str, List[float]]
+        Mapping of component name to composition at each temperature.
+    fraction_solid : List[float]
+        Fraction of solid at each temperature.
+    temperatures : List[float]
         List of simulation temperatures.
-    x_liquid : list
-        Mole fraction of the liquid phase at each temperature.
-    fraction_solid : list
-        Fraction of liquid at each temperature.
-    phase_amounts : dict
-        Dictionary of {phase_name: amount_list} where amount_list is a list of
-        instantaneus phase amounts at each temperature. Should be less than 1
-        unless the solidification all occured in 1 step (e.g. solidification
-        at the eutectic composition)
+    phase_amounts : Dict[str, float]
+        Map of {phase_name: amount_list} for solid phases where amount_list is
+        a list of instantaneus phase amounts at each temperature. Should be
+        less than 1 unless the solidification all occured in 1 step (e.g.
+        solidification at the eutectic composition)
     converged : bool
         For Scheil: True if the liquid stopping criteria was met. False otherwise
         For equilibrium: True if no liquid remains, False otherwise.
 
     Attributes
     ----------
-    fraction_liquid : list
-        Description of attribute `fraction_liquid`.
-    x_liquid
-    fraction_solid
-    temperatures
-    phase_amounts
+    x_liquid : Dict[str, List[float]
+    fraction_solid : List[float]
+    temperatures : List[float]
+    phase_amounts : Dict[str, float]
+    fraction_liquid : List[float]
+        Fraction of liquid at each temperature (convenience for 1-fraction_solid)
     cum_phase_amounts : Dict[str, list]
-        Cumulative phase amounts )
+        Map of {phase_name: amount_list} for solid phases where amount_list is
+        a list of cumulative phase amounts at each temperature.
 
     """
 

--- a/scheil/utils.py
+++ b/scheil/utils.py
@@ -5,6 +5,29 @@ from scipy.stats import norm
 from pycalphad.core.utils import unpack_components, generate_dof
 
 
+def get_phase_amounts(eq, phases):
+    """Return the phase fraction for each phase in equilibrium
+
+    Parameters
+    ----------
+    eq : pycalphad.core.light_dataset.LightDataset
+        Point equilibrium calculation result
+    phases : Sequence[str]
+        Phases to get the amounts of
+
+    Returns
+    -------
+    Dict[str, float]
+
+    """
+    phase_amnts = {ph: 0.0 for ph in phases}
+    for ph_idx in range(eq.vertex.size):
+        cur_phase = str(eq.Phase[..., ph_idx].squeeze())
+        if cur_phase in phases:
+            phase_amnts[cur_phase] += float(eq.NP[..., ph_idx].squeeze())
+    return phase_amnts
+
+
 def is_ordered(site_fracs, subl_dof, symmetric_subl_idx, **kwargs):
     """Return True if the site fraction configuration is ordered
 

--- a/tests/test_chen2009.py
+++ b/tests/test_chen2009.py
@@ -114,5 +114,5 @@ def test_ternary_A_B_C():
     # Temperature is close to t
     assert np.isclose(sol_res.temperatures[idx_last_alpha], t_temp, atol=step * 1.1)
     # Check that the compositions are resonably close as well, within 1%
-    assert np.isclose(sol_res.x_liquid[idx_last_alpha][v.X('B')], 0.583, atol=0.01)
-    assert np.isclose(sol_res.x_liquid[idx_last_alpha][v.X('C')], 0.059, atol=0.01)
+    assert np.isclose(sol_res.x_liquid['B'][idx_last_alpha], 0.583, atol=0.01)
+    assert np.isclose(sol_res.x_liquid['C'][idx_last_alpha], 0.059, atol=0.01)

--- a/tests/test_scheil_solidification.py
+++ b/tests/test_scheil_solidification.py
@@ -21,10 +21,10 @@ def test_scheil_solidification_result_properties():
     sol_res = simulate_scheil_solidification(dbf, comps, phases, initial_composition, start_temperature, step_temperature=20.0, verbose=True)
 
     num_temperatures = len(sol_res.temperatures)
-    assert num_temperatures == len(sol_res.x_liquid)
     assert num_temperatures == len(sol_res.fraction_liquid)
     assert num_temperatures == len(sol_res.fraction_solid)
     assert all([num_temperatures == len(nphase) for nphase in sol_res.phase_amounts.values()])
+    assert all([num_temperatures == len(liq_comps) for liq_comps in sol_res.x_liquid.values()])
     assert all([num_temperatures == len(nphase) for nphase in sol_res.cum_phase_amounts.values()])
 
     # final phase amounts are correct
@@ -55,10 +55,10 @@ def test_equilibrium_solidification_result_properties():
                                                   step_temperature=20.0, verbose=True)
 
     num_temperatures = len(sol_res.temperatures)
-    assert num_temperatures == len(sol_res.x_liquid)
     assert num_temperatures == len(sol_res.fraction_liquid)
     assert num_temperatures == len(sol_res.fraction_solid)
     assert all([num_temperatures == len(np) for np in sol_res.phase_amounts.values()])
+    assert all([num_temperatures == len(liq_comps) for liq_comps in sol_res.x_liquid.values()])
     assert all([num_temperatures == len(nphase) for nphase in sol_res.cum_phase_amounts.values()])
     # The final cumulative solid phase amounts is 1.0
     assert np.isclose(np.sum([amnts[-1] for amnts in sol_res.cum_phase_amounts.values()]), 1.0)

--- a/tests/test_scheil_solidification.py
+++ b/tests/test_scheil_solidification.py
@@ -49,7 +49,6 @@ def test_equilibrium_solidification_result_properties():
 
     initial_composition = {v.X('ZN'): 0.3}
     start_temperature = 850
-    end_temperature = 650
 
     sol_res = simulate_equilibrium_solidification(dbf, comps, phases, initial_composition,
                                                   start_temperature=start_temperature,

--- a/tests/test_scheil_solidification.py
+++ b/tests/test_scheil_solidification.py
@@ -53,7 +53,6 @@ def test_equilibrium_solidification_result_properties():
 
     sol_res = simulate_equilibrium_solidification(dbf, comps, phases, initial_composition,
                                                   start_temperature=start_temperature,
-                                                  end_temperature=end_temperature,
                                                   step_temperature=20.0, verbose=True)
 
     num_temperatures = len(sol_res.temperatures)


### PR DESCRIPTION
* Equilibrium simulations now find the ending temperature automatically, instead of being given an end temperature which may or may not completely solidify. At the end of an equilibrium solidification simulation, a binary search is performed to find the solidus temperature to a specified tolerance for more accurate phase fractions. Closes #6 
* [Breaking] the liquid composition input and attribute (`x_liquid`) SolidificationResult is now a `Dict[component name, List[composition]]` rather than a `List[Dict[Composition state variable, composition]]`. The old method is easier in terms of doing further equilibrium calculations by updating condition dicts, but the new method is better for post-processing and plotting, since the last dimension is directly aligned with the temperature dimension.