### PR TITLE
FIX: Force exit in equilibrium solidification after a successful binary search

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,5 +33,4 @@ jobs:
         cd ..
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
     - run: python -m pip install --editable .
-    - name: Test with pytest
-      run: pytest -v --doctest-modules scheil tests
+    - run: python -m pytest -v --doctest-modules scheil tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,6 +6,7 @@ jobs:
   Tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 100
       matrix:
         python-version: [3.7, 3.8, 3.9]
@@ -31,5 +32,8 @@ jobs:
         python -m pip install --no-build-isolation .
         cd ..
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
+    - name: Install pycalphad release version
+      run: python -m pip install --editable .
+      if: !matrix.pycalphad_develop_version
     - name: Test with pytest
       run: pytest -v --doctest-modules scheil tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -32,6 +32,6 @@ jobs:
         python -m pip install --no-build-isolation .
         cd ..
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
-    - name: python -m pip install --editable .
+    - run: python -m pip install --editable .
     - name: Test with pytest
       run: pytest -v --doctest-modules scheil tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,4 +34,4 @@ jobs:
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
     - run: python -m pip install --editable .
     - run: python -m pip list
-    - run: python -m pytest -s -v --doctest-modules scheil tests
+    - run: python -m pytest -s -v --doctest-modules scheil tests -k test_equilibrium_solidification_result_properties

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,4 +34,4 @@ jobs:
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
     - run: python -m pip install --editable .
     - run: python -m pip list
-    - run: python -m pytest -v --doctest-modules scheil tests
+    - run: python -m pytest -s -v --doctest-modules scheil tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -32,8 +32,6 @@ jobs:
         python -m pip install --no-build-isolation .
         cd ..
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
-    - name: Install pycalphad release version
-      run: python -m pip install --editable .
-      if: ${{ !matrix.pycalphad_develop_version }}
+    - name: python -m pip install --editable .
     - name: Test with pytest
       run: pytest -v --doctest-modules scheil tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,6 +34,6 @@ jobs:
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
     - name: Install pycalphad release version
       run: python -m pip install --editable .
-      if: !matrix.pycalphad_develop_version
+      if: ${{ !matrix.pycalphad_develop_version }}
     - name: Test with pytest
       run: pytest -v --doctest-modules scheil tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,4 +33,5 @@ jobs:
         cd ..
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
     - run: python -m pip install --editable .
+    - run: python -m pip list
     - run: python -m pytest -v --doctest-modules scheil tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 100
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         pycalphad_develop_version: [true, false]
 
     steps:
@@ -20,21 +20,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        $CONDA/bin/conda env update --file environment.yml --name base
+      run: python -m pip install -U pip setuptools pytest
     - name: Install pycalphad development version
       if: matrix.pycalphad_develop_version
       run: |
-        $CONDA/bin/conda remove --force pycalphad
         git clone https://github.com/pycalphad/pycalphad pycalphad-dev
         cd pycalphad-dev
         git checkout develop
-        $CONDA/bin/pip install --no-deps -e .
+        python -m pip install -r requirements-dev.txt
+        python -m pip install --no-build-isolation .
         cd ..
-        $CONDA/bin/python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
+        python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
     - name: Test with pytest
-      run: |
-        conda install pytest
-        conda list
-        $CONDA/bin/pytest -v --doctest-modules scheil tests
+      run: pytest -v --doctest-modules scheil tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,4 +34,4 @@ jobs:
         python -c 'import pycalphad; print(f"pycalphad version: {pycalphad.__version__}")'
     - run: python -m pip install --editable .
     - run: python -m pip list
-    - run: python -m pytest -s -v --doctest-modules scheil tests -k test_equilibrium_solidification_result_properties
+    - run: python -m pytest -v --doctest-modules scheil tests

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,0 @@
-name: base
-channels:
-  - conda-forge
-dependencies:
-  - numpy
-  - pycalphad>=0.8.1
-  - scipy

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -350,6 +350,8 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
             else:
                 phase_amounts[solid_phase].append(amount - cum_phase_amounts[solid_phase][-2])
             current_fraction_solid += amount
+        print('cum_phase_amounts', cum_phase_amounts)
+        print('current_fraction_solid', current_fraction_solid)
         fraction_solid.append(current_fraction_solid)
 
     converged = True if np.isclose(fraction_solid[-1], 1.0) else False

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -278,7 +278,7 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
     current_T = start_temperature
     if verbose:
         print('T=')
-    while fraction_solid[-1] < 1 if len(fraction_solid) > 0 else not converged:
+    while (fraction_solid[-1] < 1 if len(fraction_solid) > 0 else True) and not converged:
         sys.stdout.flush()
         conds[v.T] = current_T
         if verbose:

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -278,7 +278,7 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
     current_T = start_temperature
     if verbose:
         print('T=')
-    while fraction_solid[-1] < 1 if len(fraction_solid) > 0 else True:
+    while fraction_solid[-1] < 1 if len(fraction_solid) > 0 else not converged:
         sys.stdout.flush()
         conds[v.T] = current_T
         if verbose:
@@ -321,6 +321,7 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
                     T_high = bin_search_T
                 else:
                     T_low = bin_search_T
+            converged = True
             conds[v.T] = T_low
             temperatures.append(T_low)
             eq = equilibrium(dbf, comps, phases, conds, callables=cbs, model=models, to_xarray=False, **eq_kwargs)
@@ -350,8 +351,6 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
             else:
                 phase_amounts[solid_phase].append(amount - cum_phase_amounts[solid_phase][-2])
             current_fraction_solid += amount
-        print('cum_phase_amounts', cum_phase_amounts)
-        print('current_fraction_solid', current_fraction_solid)
         fraction_solid.append(current_fraction_solid)
 
     converged = True if np.isclose(fraction_solid[-1], 1.0) else False

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tests/test_scheil_solidification.py
+++ b/tests/test_scheil_solidification.py
@@ -2,7 +2,6 @@ import os
 import json
 import numpy as np
 from pycalphad import Database, variables as v
-from pycalphad.core.equilibrium import equilibrium
 from scheil import simulate_scheil_solidification, simulate_equilibrium_solidification, SolidificationResult
 
 
@@ -68,9 +67,6 @@ def test_equilibrium_solidification_result_properties():
 
     initial_composition = {v.X('ZN'): 0.3}
     start_temperature = 850
-    print('start eq')
-    print(equilibrium(dbf, comps, phases, {v.P: 101325, v.N: 1, v.T: start_temperature, **initial_composition}))
-    print('done')
     sol_res = simulate_equilibrium_solidification(dbf, comps, phases, initial_composition,
                                                   start_temperature=start_temperature,
                                                   step_temperature=20.0, verbose=True)

--- a/tests/test_scheil_solidification.py
+++ b/tests/test_scheil_solidification.py
@@ -2,6 +2,7 @@ import os
 import json
 import numpy as np
 from pycalphad import Database, variables as v
+from pycalphad.core.equilibrium import equilibrium
 from scheil import simulate_scheil_solidification, simulate_equilibrium_solidification, SolidificationResult
 
 
@@ -67,7 +68,9 @@ def test_equilibrium_solidification_result_properties():
 
     initial_composition = {v.X('ZN'): 0.3}
     start_temperature = 850
-
+    print('start eq')
+    print(equilibrium(dbf, comps, phases, {v.P: 101325, v.N: 1, v.T: start_temperature, **initial_composition}))
+    print('done')
     sol_res = simulate_equilibrium_solidification(dbf, comps, phases, initial_composition,
                                                   start_temperature=start_temperature,
                                                   step_temperature=20.0, verbose=True)


### PR DESCRIPTION
- Exit the equilibrium solidification while loop after a binary search, because the solidification must be converged then by definition (fixes a floating point precision issue where `0.999... < 1` caused the loop to be infinite on some platforms.
- Update CI for pip version of pycalphad
- Remove environment.yml development file
- Drop Python 3.6