### PR TITLE
FIX: Fix removing disordered phase candidates

### DIFF
--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -87,20 +87,21 @@ def simulate_scheil_solidification(dbf, comps, phases, composition,
     MAXIMUM_STEP_SIZE_REDUCTION = 5.0
     T_STEP_ORIG = step_temperature
     phases = filter_phases(dbf, unpack_components(dbf, comps), phases)
+    ord_disord_dict = order_disorder_dict(dbf, comps, phases)
     models = instantiate_models(dbf, comps, phases)
     if verbose:
         print('building callables... ', end='')
     cbs = build_callables(dbf, comps, phases, models, additional_statevars={v.P, v.T, v.N}, build_gradients=True, build_hessians=True)
     if verbose:
         print('done')
-    solid_phases = sorted(set(phases) - {liquid_phase_name})
+    filtered_disordered_phases = {ord_ph_dict['disordered_phase'] for ord_ph_dict in ord_disord_dict.values()}
+    solid_phases = sorted((set(phases) | filtered_disordered_phases) - {liquid_phase_name})
     temp = start_temperature
     independent_comps = sorted([str(comp)[2:] for comp in composition.keys()])
     x_liquid = {comp: [composition[v.X(comp)]] for comp in independent_comps}
     fraction_solid = [0.0]
     temperatures = [temp]
     phase_amounts = {ph: [0.0] for ph in solid_phases}
-    ord_disord_dict = order_disorder_dict(dbf, comps, phases)
 
     if adaptive and ('points' in eq_kwargs.get('calc_opts', {})):
         # Dynamically add points as the simulation runs
@@ -250,7 +251,8 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
     eq_kwargs = eq_kwargs or dict()
     phases = filter_phases(dbf, unpack_components(dbf, comps), phases)
     ord_disord_dict = order_disorder_dict(dbf, comps, phases)
-    solid_phases = sorted(set(phases) - {liquid_phase_name})
+    filtered_disordered_phases = {ord_ph_dict['disordered_phase'] for ord_ph_dict in ord_disord_dict.values()}
+    solid_phases = sorted((set(phases) | filtered_disordered_phases) - {liquid_phase_name})
     independent_comps = sorted([str(comp)[2:] for comp in composition.keys()])
     models = instantiate_models(dbf, comps, phases)
     if verbose:

--- a/scheil/utils.py
+++ b/scheil/utils.py
@@ -69,7 +69,7 @@ def is_ordered(site_fracs, subl_dof, symmetric_subl_idx, **kwargs):
     # fractions of that particular sublattice from the site fraction array
     subl_slices = []
     for subl_idx in range(len(subl_dof)):
-        start_idx = np.sum(subl_dof[:subl_idx], dtype=np.int)
+        start_idx = np.sum(subl_dof[:subl_idx], dtype=np.int_)
         end_idx = start_idx + subl_dof[subl_idx]
         subl_slices.append(slice(start_idx, end_idx))
 
@@ -197,4 +197,3 @@ def local_sample(sitefracs, comp_count, pdens=100, stddev=0.05):
         pts[:, cur_idx:end_idx] /= pts[:, cur_idx:end_idx].sum(axis=1)[:, None]
         cur_idx = end_idx
     return pts
-


### PR DESCRIPTION
Fixes a regression introduced in #11, where `filter_phases` was introduced to remove phases that cannot be stable or phases where the disordered part is given as a candidate phase. The change in #11 made it so the disordered phase was not a part of the list of `solid_phases` that could form during the solidification simulations. With the disordered phase name not included in the `solid_phases`, the `order_disorder_eq_phases` function that renamed the ordered phases with disordered configurations to their disordered counterpart would lead to the phase amount of disordered configurations to _not_ be saved.

This PR fixes that and adds a parameterized test case that tests that the disordered phase always is accounted for regardless of whether or not the ordered phase is in the candidate phases or not.