### PR TITLE
ENH: Build phase records instead of callables

### DIFF
--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -1,7 +1,7 @@
 import sys
 import numpy as np
 from pycalphad import equilibrium, variables as v
-from pycalphad.codegen.callables import build_callables, build_phase_records
+from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.utils import instantiate_models, generate_dof, \
     unpack_components, filter_phases
 from .solidification_result import SolidificationResult

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -91,8 +91,7 @@ def simulate_scheil_solidification(dbf, comps, phases, composition,
     models = instantiate_models(dbf, comps, phases)
     if verbose:
         print('building PhaseRecord objects... ', end='')
-    # Dummy N, P, T conditions to ensure that we build PhaseRecords for all state variables
-    phase_records = build_phase_records(dbf, comps, phases, {v.N: None, v.P: None, v.T: None}, models)
+    phase_records = build_phase_records(dbf, comps, phases, [v.N, v.P, v.T], models)
     if verbose:
         print('done')
     filtered_disordered_phases = {ord_ph_dict['disordered_phase'] for ord_ph_dict in ord_disord_dict.values()}
@@ -258,8 +257,7 @@ def simulate_equilibrium_solidification(dbf, comps, phases, composition,
     models = instantiate_models(dbf, comps, phases)
     if verbose:
         print('building PhaseRecord objects... ', end='')
-    # Dummy N, P, T conditions to ensure that we build PhaseRecords for all state variables
-    phase_records = build_phase_records(dbf, comps, phases, {v.N: None, v.P: None, v.T: None}, models)
+    phase_records = build_phase_records(dbf, comps, phases, [v.N, v.P, v.T], models)
     if verbose:
         print('done')
     conds = {v.P: 101325, v.N: 1.0}

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'numpy',
         'scipy',
         'setuptools_scm[toml]>=6.0',
-        'pycalphad>=0.8.1',
+        'pycalphad>=0.9.1',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Uses the pycalphad API to pass `PhaseRecord` dictionaries to `calculate` and `equilibrium` to improve the tight-loop performance of equilibrium and Scheil solidification simulations https://github.com/pycalphad/pycalphad/pull/361.

Building phase records can give a significant performance boost, roughly 10x to 100x speedup in some cases.