### PR TITLE
ENH: use adaptive sampling by default

### DIFF
--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -116,12 +116,17 @@ def simulate_scheil_solidification(dbf, comps, phases, composition,
         eq_kwargs.setdefault('calc_opts', {})
         # TODO: handle per-phase/unpackable points and pdens
         if 'points' not in eq_kwargs['calc_opts']:
-            # construct a points dict for the user
+            if verbose:
+                print('generating points... ', end='')
             points_dict = {}
             for phase_name, mod in models.items():
+                if verbose:
+                    print(phase_name, end=' ')
                 pdens = eq_kwargs['calc_opts'].get('pdens', 50)
                 points_dict[phase_name] = _sample_phase_constitution(mod, point_sample, True, pdens=pdens)
             eq_kwargs['calc_opts']['points'] = points_dict
+            if verbose:
+                print('done')
 
     converged = False
     phases_seen = {liquid_phase_name, ''}

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -3,8 +3,7 @@ import numpy as np
 from pycalphad import equilibrium, variables as v
 from pycalphad.codegen.callables import build_phase_records
 from pycalphad.core.calculate import _sample_phase_constitution
-from pycalphad.core.utils import point_sample
-from pycalphad.core.utils import instantiate_models, unpack_components, filter_phases
+from pycalphad.core.utils import instantiate_models, unpack_components, filter_phases, point_sample
 from .solidification_result import SolidificationResult
 from .utils import order_disorder_dict, local_sample, order_disorder_eq_phases, get_phase_amounts
 
@@ -48,7 +47,7 @@ def _update_points(eq, points_dict, dof_dict, local_pdens=0, verbose=False):
             if verbose:
                 print(f'Adding points to {ph}. ', end='')
             dof = dof_dict[ph]
-            eq_pts = eq.Y.squeeze()[vtx, :].reshape(1, -1)[:, :sum(dof)]
+            eq_pts = eq.Y.squeeze()[vtx, :sum(dof)].reshape(1, -1)
             if local_pdens > 0:
                 points_dict[ph] = np.concatenate([pts, local_sample(eq_pts, dof, pdens=local_pdens)], axis=0)
             else:

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -48,10 +48,11 @@ def _update_points(eq, points_dict, dof_dict, local_pdens=0, verbose=False):
             if verbose:
                 print(f'Adding points to {ph}. ', end='')
             dof = dof_dict[ph]
+            eq_pts = eq.Y.squeeze()[vtx, :].reshape(1, -1)[:, :sum(dof)]
             if local_pdens > 0:
-                points_dict[ph] = np.concatenate([pts, local_sample(eq.Y.squeeze()[vtx, :sum(dof)].reshape(1, -1), dof, pdens=local_pdens)], axis=0)
+                points_dict[ph] = np.concatenate([pts, local_sample(eq_pts, dof, pdens=local_pdens)], axis=0)
             else:
-                points_dict[ph] = np.concatenate([pts, eq.Y.squeeze()[vtx, :sum(dof)].reshape(1, -1)], axis=0)
+                points_dict[ph] = np.concatenate([pts, eq_pts], axis=0)
 
 
 def simulate_scheil_solidification(dbf, comps, phases, composition,

--- a/scheil/utils.py
+++ b/scheil/utils.py
@@ -164,7 +164,6 @@ def order_disorder_eq_phases(eq_result, order_disorder_dict):
 def local_sample(sitefracs, comp_count, pdens=100, stddev=0.05):
     """Sample from a normal distribution around the optimal site fractions
 
-
     Parameters
     ----------
     sitefracs : np.ndarray[:, :]


### PR DESCRIPTION
- Points dictionaries are now created for the user by default if they are not provided.
- Adaptive sampling does not do any "local" random sampling by default, it just adds the point from the solution
- Don't use `pycalphad.core.utils.generate_dof` to create the `dof_dict` (it is deprecated)