### PR TITLE
Workspace compat

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       max-parallel: 100
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         pycalphad_develop_version: [true, false]
 
     steps:

--- a/scheil/simulate.py
+++ b/scheil/simulate.py
@@ -128,7 +128,7 @@ def simulate_scheil_solidification(dbf, comps, phases, composition,
                 pdens = eq_kwargs['calc_opts'].get('pdens', 50)
                 # Assume no phase_local_conditions, this is probably okay since there's no option to add additional conditions here
                 # And I don't think it would make too much sense to have phase local conditions for scheil/eq solidification anyways
-                points_dict[phase_name] = _sample_phase_constitution(mod, point_sample, True, pdens=pdens, phase_local_conditions = {})
+                points_dict[phase_name] = _sample_phase_constitution(mod, point_sample, True, pdens=pdens, phase_local_conditions={})
             eq_kwargs['calc_opts']['points'] = points_dict
             if verbose:
                 print('done')

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,9 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )


### PR DESCRIPTION
This makes the minimal changes to be compatible with Workspace.
 
Main changes are:
- replace build_phase_records with PhaseRecordFactory
- Add empty dict to phase_local_conditions when called _sample_phase_constitution
- Update python versions in setup.py and pytest.yaml to be 3.9, 3.10, 3.11, 3.12

\
I suppose more integration with Workspace can be useful:
- Replace calls to equilibrium with using a Workspace object(s)
- Copying my comment from #33 : with the property framework, we may only need to store the global conditions, chemical potentials and composition sets at each iteration. Then any property that satisfies the ComputableProperty protocol can be extracted from a Scheil result. 
  - Then we could use a similar API to do something like `scheil_result.get("T", "FS")` to get T and solid fraction
  - We may still have to store fraction_solid, fraction_liquid and potential phase_amounts (although this can be computed from NP and fraction_liquid) since they depend on the previous calculations and not just the current equilibrium calculation.